### PR TITLE
Stop feed when plugin is disabled

### DIFF
--- a/app/jobs/jobs/discourse_rss_polling/poll_all_feeds.rb
+++ b/app/jobs/jobs/discourse_rss_polling/poll_all_feeds.rb
@@ -6,6 +6,8 @@ module Jobs
       every 5.minutes
 
       def execute(args)
+        return unless SiteSetting.rss_polling_enabled
+
         poll_all_feeds if not_polled_recently?
       end
 

--- a/app/jobs/jobs/discourse_rss_polling/poll_feed.rb
+++ b/app/jobs/jobs/discourse_rss_polling/poll_feed.rb
@@ -6,6 +6,8 @@ module Jobs
   module DiscourseRssPolling
     class PollFeed < ::Jobs::Base
       def execute(args)
+        return unless SiteSetting.rss_polling_enabled
+
         @feed_url = args[:feed_url]
         @author = User.find_by_username(args[:author_username])
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -7,4 +7,4 @@ en:
       rss_polling:
         author: Author
         feed_url: Feed URL
-        remember_to_add_allowed_hosts: Remember to add them as Allowed Hosts in "Customize > Embedding"
+        remember_to_add_allowed_hosts: To set the Discourse category that your feed will be published to, add the domain of the feed's link attributes to the Allowed Hosts section of your Admin / Customize / Embedding page.

--- a/spec/jobs/poll_all_feeds_spec.rb
+++ b/spec/jobs/poll_all_feeds_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Jobs::DiscourseRssPolling::PollAllFeeds do
+  SiteSetting.rss_polling_enabled = true
   let(:job) { Jobs::DiscourseRssPolling::PollAllFeeds.new }
 
   describe '#execute' do
@@ -34,6 +35,18 @@ RSpec.describe Jobs::DiscourseRssPolling::PollAllFeeds do
       Sidekiq::Testing.fake! do
         expect { job.execute({}) }.to change { Jobs::DiscourseRssPolling::PollFeed.jobs.size }.by(2)
         expect { job.execute({}) }.to_not change { Jobs::DiscourseRssPolling::PollFeed.jobs.size }
+      end
+    end
+
+    context 'When the plugin is disabled' do
+      before do
+        SiteSetting.rss_polling_enabled = false
+      end
+
+      it 'does not queue PollFeed jobs' do
+        Sidekiq::Testing.fake! do
+          expect { job.execute({}) }.to change { Jobs::DiscourseRssPolling::PollFeed.jobs.size }.by(0)
+        end
       end
     end
   end

--- a/spec/jobs/poll_feed_spec.rb
+++ b/spec/jobs/poll_feed_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Jobs::DiscourseRssPolling::PollFeed do
+  SiteSetting.rss_polling_enabled = true
   let(:feed_url) { 'https://blog.discourse.org/feed/' }
   let(:author) { Fabricate(:user) }
   let(:raw_feed) { file_from_fixtures('feed.rss', 'feed') }

--- a/spec/models/feed_setting_spec.rb
+++ b/spec/models/feed_setting_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe DiscourseRssPolling::FeedSetting do
+  SiteSetting.rss_polling_enabled = true
   let(:feed_url) { 'https://blog.discourse.org/feed/' }
   let(:author) { Fabricate(:user) }
   let(:feed_setting) { DiscourseRssPolling::FeedSetting.new(feed_url: feed_url, author_username: author.username) }


### PR DESCRIPTION
Adds a check to the `poll_feed` and `poll_all_feeds` jobs to see if the plugin is enabled before pulling in the feed.

Updates the copy for the `remember_to_add_allowed_hosts` setting to indicate how to set the feed topics category. For feeds that use multiple domains, multiple Discourse categories can be configured through the Allowed Hosts section. I didn't indicate this in the copy though.

I didn't deal with the minor issue of the two `jobs` directories. I can see why that approach is being used to load the jobs files.

The plugin's spec files are now calling `SiteSetting.rss_polling_enabled = true` where required. There is a test for when the setting is not enabled added to `poll_all_feeds_spec.rb`.