### PR TITLE
FIX: Makes sure to convert HTML entities on the title of the post

### DIFF
--- a/app/jobs/jobs/discourse_rss_polling/poll_feed.rb
+++ b/app/jobs/jobs/discourse_rss_polling/poll_feed.rb
@@ -28,7 +28,7 @@ module Jobs
 
       def poll_feed
         topics_polled_from_feed.each do |topic|
-          TopicEmbed.import(author, topic.url, topic.title, CGI.unescapeHTML(topic.content)) if topic.content.present?
+          TopicEmbed.import(author, topic.url, CGI.unescapeHTML(topic.title), CGI.unescapeHTML(topic.content)) if topic.content.present?
         end
       end
 


### PR DESCRIPTION
The plugin currently converts HTML entities in the body, this adds the same conversion to the title to avoid encoding issues.

This was causing errors where the title of the post converted from an RSS feed will look like this:

![image](https://user-images.githubusercontent.com/2375050/104530731-7fc76800-5671-11eb-9050-c4e5001d201f.png)

Example RSS feed: http://talkwellington.org.nz/?feed=atom

I have tested this fix on our discourse instance and it works ok. It also goes and edits existing posts to fix the title if they are still in the RSS feed.

Let me know if this is the correct place to add the fix to.
Please don't hesitate to ask me questions.