### PR TITLE
DEV: Remove verbose logging

### DIFF
--- a/app/jobs/jobs/discourse_rss_polling/poll_feed.rb
+++ b/app/jobs/jobs/discourse_rss_polling/poll_feed.rb
@@ -42,7 +42,7 @@ module Jobs
       end
 
       def fetch_raw_feed
-        final_destination = FinalDestination.new(@feed_url, verbose: true)
+        final_destination = FinalDestination.new(@feed_url)
         feed_final_url = final_destination.resolve
         return nil unless final_destination.status == :resolved
 


### PR DESCRIPTION
All other feed polling operations silence exceptions, but we log when a
timeout happens via `FinalDestination`. Let's avoid log pollution by
turning this off.