### PR TITLE
FEATURE: Allow to filter from feed category substring matches

### DIFF
--- a/app/jobs/jobs/discourse_rss_polling/poll_feed.rb
+++ b/app/jobs/jobs/discourse_rss_polling/poll_feed.rb
@@ -31,9 +31,8 @@ module Jobs
 
       def poll_feed
         topics_polled_from_feed.each do |topic|
-
           next if !topic.content.present?
-          next if (feed_category_filter.present? && !topic.categories.include?(feed_category_filter))
+          next if (feed_category_filter.present? && topic.categories.none? { |c| c.include?(feed_category_filter) })
 
           TopicEmbed.import(author, topic.url, topic.title, CGI.unescapeHTML(topic.content), category_id: discourse_category_id, tags: discourse_tags, cook_method: topic.is_youtube? ? Post.cook_methods[:regular] : nil)
         end


### PR DESCRIPTION
Currently only allow filters that match the entire category string.

However, since RSS feeds out there will have items with multiple
categories under a single XML element and using separators that won't be
properly parsed by the ruby rss standard library, we need to allow
substring matches to accomodate those.

For example, the AWS "What's New With AWS" feed at
https://aws.amazon.com/about-aws/whats-new/recent/feed/ will have
categories like:

```xml
  <category>
    general:products/amazon-rds-for-oracle,general:products/amazon-rds,marketing:marchitecture/databases
  </category>
```

So our optins are either handling lots of corner cases with custom
spliters (like comma in the example above) or simply allowing a
substring match, which is the approach used here.
