### PR TITLE
FIX: Fail fast if user is nil

### DIFF
--- a/app/jobs/jobs/discourse_rss_polling/poll_feed.rb
+++ b/app/jobs/jobs/discourse_rss_polling/poll_feed.rb
@@ -9,7 +9,7 @@ module Jobs
         return unless SiteSetting.rss_polling_enabled
 
         @feed_url = args[:feed_url]
-        @author = User.find_by_username(args[:author_username])
+        @author = User.find_by_username!(args[:author_username])
         @discourse_category_id = args[:discourse_category_id]
         @discourse_tags = args[:discourse_tags]
         @feed_category_filter = args[:feed_category_filter]


### PR DESCRIPTION
Even though the UI prevents adding a non-existent user, maybe through a
username rename or some other non-standard event it is possible to have
an RSS feed that tries to create embeded topics for a user that does not
exist. If this happens we should throw an error and not poll the rss
feed.

This fix ensures that the username exists before polling and prevents
this error in Discourse core:

`Job exception: undefined method `suspended?' for nil:NilClass`

Stack trace:

```
/var/www/discourse/lib/post_creator.rb:94:in `valid?'
/var/www/discourse/lib/post_creator.rb:204:in `create'
/var/www/discourse/app/models/topic_embed.rb:69:in `block in import'
...
/var/www/discourse/app/models/topic_embed.rb:47:in `import'
/var/www/discourse/plugins/discourse-rss-polling/app/jobs/jobs/discourse_rss_polling/poll_feed.rb:37:in `block in poll_feed'
/var/www/discourse/plugins/discourse-rss-polling/app/jobs/jobs/discourse_rss_polling/poll_feed.rb:33:in `each'
/var/www/discourse/plugins/discourse-rss-polling/app/jobs/jobs/discourse_rss_polling/poll_feed.rb:33:in `poll_feed'
/var/www/discourse/plugins/discourse-rss-polling/app/jobs/jobs/discourse_rss_polling/poll_feed.rb:17:in `execute'
```

An error is still thrown because this is something we want to halt
execution of the background job and we want to be alerted in the logs
about it.