### PR TITLE
FIX: Do not raise if user does not exist

### DIFF
--- a/app/jobs/jobs/discourse_rss_polling/poll_feed.rb
+++ b/app/jobs/jobs/discourse_rss_polling/poll_feed.rb
@@ -8,8 +8,10 @@ module Jobs
       def execute(args)
         return unless SiteSetting.rss_polling_enabled
 
+        @author = User.find_by_username(args[:author_username])
+        return if !@author
+
         @feed_url = args[:feed_url]
-        @author = User.find_by_username!(args[:author_username])
         @discourse_category_id = args[:discourse_category_id]
         @discourse_tags = args[:discourse_tags]
         @feed_category_filter = args[:feed_category_filter]


### PR DESCRIPTION
This is a very rare case, but can occur. When it does, the job will be retried
over and over and will remain stuck in the queue as it will never succeed.

Follow-up-to: 3930a82ca8603038603543ce2e7433860db3478e