### PR TITLE
FIX: Guard parsed feed items access

### DIFF
--- a/app/jobs/jobs/discourse_rss_polling/poll_feed.rb
+++ b/app/jobs/jobs/discourse_rss_polling/poll_feed.rb
@@ -49,7 +49,11 @@ module Jobs
       def topics_polled_from_feed
         raw_feed = fetch_raw_feed
         return [] if raw_feed.blank?
-        RSS::Parser.parse(raw_feed, false).items.map { |item| ::DiscourseRssPolling::FeedItem.new(item) }
+
+        parsed_feed = RSS::Parser.parse(raw_feed, false)
+        return [] if parsed_feed.blank?
+
+        parsed_feed.items.map { |item| ::DiscourseRssPolling::FeedItem.new(item) }
       rescue RSS::NotWellFormedError, RSS::InvalidRSSError
         []
       end

--- a/spec/jobs/poll_feed_spec.rb
+++ b/spec/jobs/poll_feed_spec.rb
@@ -46,5 +46,13 @@ RSpec.describe Jobs::DiscourseRssPolling::PollFeed do
 
       expect(author.topics.last).to be_nil
     end
+
+    it "does not raise error for valid xml but non-rss content" do
+      stub_request(:get, feed_url).to_return(status: 200, body: "<html><body>tesing</body></html>")
+
+      expect {
+        job.execute(feed_url: feed_url, author_username: author.username)
+      }.not_to raise_error
+    end
   end
 end


### PR DESCRIPTION
`RSS::Parser.parse` returns `nil` for valid xml content which isn't really a valid RSS document.

Ensure parse result isn't nil before processing.