### PR TITLE
DEV: Use db table instead of site setting yml

### DIFF
--- a/app/controllers/discourse_rss_polling/feed_settings_controller.rb
+++ b/app/controllers/discourse_rss_polling/feed_settings_controller.rb
@@ -15,12 +15,12 @@ module DiscourseRssPolling
         # Temporary until we start using IDs from the db
         # and can update individual items
         if feed_setting_params.presence
-          current_feeds = RssFeed.all.as_json
+          current_feeds = RssFeed.all
           feed_setting_params.each do |feed|
             current_feeds.delete_if do |h|
-              h["url"] == feed["feed_url"] &&
-                h["category_id"].to_i == feed["discourse_category_id"].to_i &&
-                h["category_filter"] == feed["feed_category_filter"]
+              h.url == feed["feed_url"] &&
+                h.category_id == feed["discourse_category_id"].to_i &&
+                h.category_filter == feed["feed_category_filter"]
             end
             rss_feed =
               RssFeed.find_by(
@@ -29,26 +29,26 @@ module DiscourseRssPolling
                 category_filter: feed["feed_category_filter"],
               )
             if rss_feed
-              rss_feed.update(
+              rss_feed.update!(
                 url: feed["feed_url"],
                 author: feed["author_username"],
                 category_id: feed["discourse_category_id"],
-                tags: feed["discourse_tags"].nil? ? nil : feed["discourse_tags"].join(","),
+                tags: feed["discourse_tags"]&.join(","),
                 category_filter: feed["feed_category_filter"],
               )
             else
-              RssFeed.create(
+              RssFeed.create!(
                 url: feed["feed_url"],
                 author: feed["author_username"],
                 category_id: feed["discourse_category_id"],
-                tags: feed["discourse_tags"].nil? ? nil : feed["discourse_tags"].join(","),
+                tags: feed["discourse_tags"]&.join(","),
                 category_filter: feed["feed_category_filter"],
               )
             end
           end
 
           # Delete any remaining feeds
-          current_feeds.each { |feed| RssFeed.destroy_by(id: feed["id"]) }
+          current_feeds&.each { |feed| RssFeed.destroy_by(id: feed.id) }
         end
       end
 

--- a/app/controllers/discourse_rss_polling/feed_settings_controller.rb
+++ b/app/controllers/discourse_rss_polling/feed_settings_controller.rb
@@ -46,7 +46,7 @@ module DiscourseRssPolling
             end
 
             # Delete any remaining feeds
-            current_feeds.each { |feed| RssFeed.destroy_by(id: feed.id) }
+            current_feeds.each { |f| RssFeed.destroy_by(id: f.id) }
           end
         end
       end

--- a/app/controllers/discourse_rss_polling/feed_settings_controller.rb
+++ b/app/controllers/discourse_rss_polling/feed_settings_controller.rb
@@ -24,7 +24,20 @@ module DiscourseRssPolling
           end
       end
 
-      SiteSetting.rss_polling_feed_setting = new_feed_settings.to_yaml
+      #SiteSetting.rss_polling_feed_setting = new_feed_settings.to_yaml
+
+      if feed_setting_params.presence
+        feed_settings_params.each do |feed|
+          f = RssFeed.find_by(url: feed.feed_url)
+          if f
+            #update
+          else
+            #create
+          end
+        end
+      end
+
+      # delete?
 
       render json: FeedSettingFinder.all
     end

--- a/app/controllers/discourse_rss_polling/feed_settings_controller.rb
+++ b/app/controllers/discourse_rss_polling/feed_settings_controller.rb
@@ -23,7 +23,12 @@ module DiscourseRssPolling
                 h["category_id"].to_i == feed["discourse_category_id"].to_i &&
                 h["category_filter"] == feed["feed_category_filter"]
             end
-            rss_feed = RssFeed.find_by(url: feed["feed_url"], category_id: feed["discourse_category_id"], category_filter: feed["feed_category_filter"])
+            rss_feed =
+              RssFeed.find_by(
+                url: feed["feed_url"],
+                category_id: feed["discourse_category_id"],
+                category_filter: feed["feed_category_filter"],
+              )
             if rss_feed
               rss_feed.update(
                 url: feed["feed_url"],

--- a/app/controllers/discourse_rss_polling/feed_settings_controller.rb
+++ b/app/controllers/discourse_rss_polling/feed_settings_controller.rb
@@ -9,30 +9,28 @@ module DiscourseRssPolling
     end
 
     def update
-      if params[:feed_settings] == []
-        new_feed_settings = []
-      else
-        new_feed_settings =
-          (feed_setting_params.presence || []).map do |feed_setting|
-            feed_setting.values_at(
-              :feed_url,
-              :author_username,
-              :discourse_category_id,
-              :discourse_tags,
-              :feed_category_filter,
-            )
-          end
-      end
-
-      #SiteSetting.rss_polling_feed_setting = new_feed_settings.to_yaml
 
       if feed_setting_params.presence
-        feed_settings_params.each do |feed|
-          f = RssFeed.find_by(url: feed.feed_url)
-          if f
-            #update
+        feed_setting_params.each do |feed|
+          rss_feed = RssFeed.find_by(url: feed['feed_url'])
+          # Temporary until we start using IDs from the db
+          # and can update individual items
+          if rss_feed
+            rss_feed.update(
+              url: feed['feed_url'],
+              author: feed['author_username'],
+              category_id: feed['discourse_category_id'],
+              tags: feed['discourse_tags'].nil? ? nil : feed['discourse_tags'].join(','),
+              category_filter: feed['feed_category_filter'],
+            )
           else
-            #create
+            RssFeed.create(
+              url: feed['feed_url'],
+              author: feed['author_username'],
+              category_id: feed['discourse_category_id'],
+              tags: feed['discourse_tags'].nil? ? nil : feed['discourse_tags'].join(','),
+              category_filter: feed['feed_category_filter'],
+            )
           end
         end
       end

--- a/app/controllers/discourse_rss_polling/feed_settings_controller.rb
+++ b/app/controllers/discourse_rss_polling/feed_settings_controller.rb
@@ -18,8 +18,7 @@ module DiscourseRssPolling
           current_feeds = RssFeed.all
           feed_setting_params.each do |feed|
             current_feeds.delete_if do |h|
-              h.url == feed["feed_url"] &&
-                h.category_id == feed["discourse_category_id"].to_i &&
+              h.url == feed["feed_url"] && h.category_id == feed["discourse_category_id"].to_i &&
                 h.category_filter == feed["feed_category_filter"]
             end
             rss_feed =

--- a/app/controllers/discourse_rss_polling/feed_settings_controller.rb
+++ b/app/controllers/discourse_rss_polling/feed_settings_controller.rb
@@ -44,10 +44,10 @@ module DiscourseRssPolling
                 category_filter: feed["feed_category_filter"],
               )
             end
-          end
 
-          # Delete any remaining feeds
-          current_feeds&.each { |feed| RssFeed.destroy_by(id: feed.id) }
+            # Delete any remaining feeds
+            current_feeds.each { |feed| RssFeed.destroy_by(id: feed.id) }
+          end
         end
       end
 

--- a/app/controllers/discourse_rss_polling/feed_settings_controller.rb
+++ b/app/controllers/discourse_rss_polling/feed_settings_controller.rb
@@ -18,8 +18,12 @@ module DiscourseRssPolling
         if feed_setting_params.presence
           current_feeds = RssFeed.all.as_json
           feed_setting_params.each do |feed|
-            current_feeds.delete_if { |h| h["url"] == feed["feed_url"] }
-            rss_feed = RssFeed.find_by(url: feed["feed_url"])
+            current_feeds.delete_if do |h|
+              h["url"] == feed["feed_url"] &&
+                h["category_id"].to_i == feed["discourse_category_id"].to_i &&
+                h["category_filter"] == feed["feed_category_filter"]
+            end
+            rss_feed = RssFeed.find_by(url: feed["feed_url"], category_id: feed["discourse_category_id"], category_filter: feed["feed_category_filter"])
             if rss_feed
               rss_feed.update(
                 url: feed["feed_url"],

--- a/app/controllers/discourse_rss_polling/feed_settings_controller.rb
+++ b/app/controllers/discourse_rss_polling/feed_settings_controller.rb
@@ -9,7 +9,6 @@ module DiscourseRssPolling
     end
 
     def update
-
       if params[:feed_settings] == []
         # Delete the last feed item
         RssFeed.destroy_all
@@ -19,34 +18,31 @@ module DiscourseRssPolling
         if feed_setting_params.presence
           current_feeds = RssFeed.all.as_json
           feed_setting_params.each do |feed|
-            current_feeds.delete_if { |h| h['url'] == feed['feed_url'] }
-            rss_feed = RssFeed.find_by(url: feed['feed_url'])
+            current_feeds.delete_if { |h| h["url"] == feed["feed_url"] }
+            rss_feed = RssFeed.find_by(url: feed["feed_url"])
             if rss_feed
               rss_feed.update(
-                url: feed['feed_url'],
-                author: feed['author_username'],
-                category_id: feed['discourse_category_id'],
-                tags: feed['discourse_tags'].nil? ? nil : feed['discourse_tags'].join(','),
-                category_filter: feed['feed_category_filter'],
+                url: feed["feed_url"],
+                author: feed["author_username"],
+                category_id: feed["discourse_category_id"],
+                tags: feed["discourse_tags"].nil? ? nil : feed["discourse_tags"].join(","),
+                category_filter: feed["feed_category_filter"],
               )
             else
               RssFeed.create(
-                url: feed['feed_url'],
-                author: feed['author_username'],
-                category_id: feed['discourse_category_id'],
-                tags: feed['discourse_tags'].nil? ? nil : feed['discourse_tags'].join(','),
-                category_filter: feed['feed_category_filter'],
+                url: feed["feed_url"],
+                author: feed["author_username"],
+                category_id: feed["discourse_category_id"],
+                tags: feed["discourse_tags"].nil? ? nil : feed["discourse_tags"].join(","),
+                category_filter: feed["feed_category_filter"],
               )
             end
           end
 
           # Delete any remaining feeds
-          current_feeds.each do |feed|
-            RssFeed.destroy_by(id: feed['id'])
-          end
+          current_feeds.each { |feed| RssFeed.destroy_by(id: feed["id"]) }
         end
       end
-
 
       render json: FeedSettingFinder.all
     end

--- a/app/controllers/discourse_rss_polling/feed_settings_controller.rb
+++ b/app/controllers/discourse_rss_polling/feed_settings_controller.rb
@@ -15,7 +15,7 @@ module DiscourseRssPolling
         # Temporary until we start using IDs from the db
         # and can update individual items
         if feed_setting_params.presence
-          current_feeds = RssFeed.all
+          current_feeds = RssFeed.all.to_a
           feed_setting_params.each do |feed|
             current_feeds.delete_if do |h|
               h.url == feed["feed_url"] && h.category_id == feed["discourse_category_id"].to_i &&

--- a/app/controllers/discourse_rss_polling/feed_settings_controller.rb
+++ b/app/controllers/discourse_rss_polling/feed_settings_controller.rb
@@ -10,7 +10,6 @@ module DiscourseRssPolling
 
     def update
       if params[:feed_settings] == []
-        # Delete the last feed item
         RssFeed.destroy_all
       else
         # Temporary until we start using IDs from the db

--- a/app/models/discourse_rss_polling/rss_feed.rb
+++ b/app/models/discourse_rss_polling/rss_feed.rb
@@ -2,8 +2,6 @@
 
 module DiscourseRssPolling
   class RssFeed < ActiveRecord::Base
-
     validates :url, presence: true
-
   end
 end

--- a/app/models/discourse_rss_polling/rss_feed.rb
+++ b/app/models/discourse_rss_polling/rss_feed.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module DiscourseRssPolling
+  class RssFeed < ActiveRecord::Base
+
+    validates :url, presence: true
+
+  end
+end

--- a/app/services/discourse_rss_polling/feed_setting_finder.rb
+++ b/app/services/discourse_rss_polling/feed_setting_finder.rb
@@ -4,7 +4,15 @@ module DiscourseRssPolling
   class FeedSettingFinder
     def self.by_embed_url(embed_url)
       host = URI.parse(embed_url).host.sub(/^www\./, "")
-      new.where { |feed_url, *_| feed_url.include?(host) }.take
+      feed = RssFeed.where("url LIKE ?", "%#{host}%").first
+      return nil if !feed
+      FeedSetting.new(
+        feed_url: feed.url,
+        author_username: feed.author,
+        discourse_category_id: feed.category_id,
+        discourse_tags: feed.tags.nil? ? nil : feed.tags.split(","),
+        feed_category_filter: feed.category_filter,
+      )
     end
 
     def self.all

--- a/app/services/discourse_rss_polling/feed_setting_finder.rb
+++ b/app/services/discourse_rss_polling/feed_setting_finder.rb
@@ -21,18 +21,15 @@ module DiscourseRssPolling
     end
 
     def all
-      YAML
-        .safe_load(SiteSetting.rss_polling_feed_setting)
-        .select(&@condition)
-        .map do |(feed_url, author_username, discourse_category_id, discourse_tags, feed_category_filter)|
-          FeedSetting.new(
-            feed_url: feed_url,
-            author_username: author_username,
-            discourse_category_id: discourse_category_id,
-            discourse_tags: discourse_tags,
-            feed_category_filter: feed_category_filter,
-          )
-        end
+      RssFeed.all.map do |feed|
+        FeedSetting.new(
+          feed_url: feed.url,
+          author_username: feed.author,
+          discourse_category_id: feed.category_id,
+          discourse_tags: feed.tags.nil? ? nil : feed.tags.split(','),
+          feed_category_filter: feed.category_filter,
+        )
+      end
     end
 
     def take

--- a/app/services/discourse_rss_polling/feed_setting_finder.rb
+++ b/app/services/discourse_rss_polling/feed_setting_finder.rb
@@ -26,7 +26,7 @@ module DiscourseRssPolling
           feed_url: feed.url,
           author_username: feed.author,
           discourse_category_id: feed.category_id,
-          discourse_tags: feed.tags.nil? ? nil : feed.tags.split(','),
+          discourse_tags: feed.tags.nil? ? nil : feed.tags.split(","),
           feed_category_filter: feed.category_filter,
         )
       end

--- a/db/migrate/20230318130154_create_discourse_rss_polling_rss_feeds.rb
+++ b/db/migrate/20230318130154_create_discourse_rss_polling_rss_feeds.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateDiscourseRssPollingRssFeeds < ActiveRecord::Migration[7.0]
+  def change
+    create_table :discourse_rss_polling_rss_feeds do |t|
+      t.string :url, null: false
+      t.string :category_filter
+      t.string :author
+      t.integer :category_id
+      t.string :tags
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230318130154_create_discourse_rss_polling_rss_feeds.rb
+++ b/db/migrate/20230318130154_create_discourse_rss_polling_rss_feeds.rb
@@ -3,11 +3,11 @@
 class CreateDiscourseRssPollingRssFeeds < ActiveRecord::Migration[7.0]
   def change
     create_table :discourse_rss_polling_rss_feeds do |t|
-      t.string :url, null: false
-      t.string :category_filter
-      t.string :author
+      t.string :url, null: false, length: 255
+      t.string :category_filter, length: 100
+      t.string :author, length: 100
       t.integer :category_id
-      t.string :tags
+      t.string :tags, length: 255
       t.timestamps
     end
   end

--- a/db/migrate/20230319115620_move_rss_yaml_to_db.rb
+++ b/db/migrate/20230319115620_move_rss_yaml_to_db.rb
@@ -5,7 +5,7 @@ class MoveRssYamlToDb < ActiveRecord::Migration[7.0]
     feeds = YAML.safe_load(SiteSetting.rss_polling_feed_setting)
     feeds.each do |feed|
       # ["https://blog.codinghorror.com/rss/", "system", 14, ["welcome", "another"], "category_filter"]
-      tags = feed[3].nil? ? nil : feed[3].join(',')
+      tags = feed[3].nil? ? nil : feed[3].join(",")
 
       DiscourseRssPolling::RssFeed.create(
         url: feed[0],
@@ -15,6 +15,5 @@ class MoveRssYamlToDb < ActiveRecord::Migration[7.0]
         category_filter: feed[4],
       )
     end
-
   end
 end

--- a/db/migrate/20230319115620_move_rss_yaml_to_db.rb
+++ b/db/migrate/20230319115620_move_rss_yaml_to_db.rb
@@ -22,5 +22,4 @@ class MoveRssYamlToDb < ActiveRecord::Migration[7.0]
   def down
     raise ActiveRecord::IrreversibleMigration
   end
-
 end

--- a/db/migrate/20230319115620_move_rss_yaml_to_db.rb
+++ b/db/migrate/20230319115620_move_rss_yaml_to_db.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class MoveRssYamlToDb < ActiveRecord::Migration[7.0]
+  def up
+    feeds = YAML.safe_load(SiteSetting.rss_polling_feed_setting)
+    feeds.each do |feed|
+      # ["https://blog.codinghorror.com/rss/", "system", 14, ["welcome", "another"], "category_filter"]
+      tags = feed[3].nil? ? nil : feed[3].join(',')
+
+      DiscourseRssPolling::RssFeed.create(
+        url: feed[0],
+        author: feed[1],
+        category_id: feed[2],
+        tags: tags,
+        category_filter: feed[4],
+      )
+    end
+
+  end
+end

--- a/db/migrate/20230319115620_move_rss_yaml_to_db.rb
+++ b/db/migrate/20230319115620_move_rss_yaml_to_db.rb
@@ -2,18 +2,22 @@
 
 class MoveRssYamlToDb < ActiveRecord::Migration[7.0]
   def up
-    feeds = YAML.safe_load(SiteSetting.rss_polling_feed_setting)
-    feeds.each do |feed|
-      # ["https://blog.codinghorror.com/rss/", "system", 14, ["welcome", "another"], "category_filter"]
-      tags = feed[3].nil? ? nil : feed[3].join(",")
+    rss_polling_feed_setting = DB.query("SELECT * FROM site_settings WHERE name = 'rss_polling_feed_setting' LIMIT 1").first&.value || ""
+    begin
+      feeds = YAML.safe_load(rss_polling_feed_setting)
+      feeds&.each do |(url, author, category_id, tags, category_filter)|
+        tags = tags&.join(",")
 
-      DiscourseRssPolling::RssFeed.create(
-        url: feed[0],
-        author: feed[1],
-        category_id: feed[2],
-        tags: tags,
-        category_filter: feed[4],
-      )
+        DiscourseRssPolling::RssFeed.create(
+          url:,
+          author:,
+          category_id:,
+          tags:,
+          category_filter:,
+        )
+      rescue Psych::SyntaxError => ex
+        # We don't want the migration to fail if invalid yaml exists for some reason
+      end
     end
   end
 end

--- a/db/migrate/20230319115620_move_rss_yaml_to_db.rb
+++ b/db/migrate/20230319115620_move_rss_yaml_to_db.rb
@@ -2,19 +2,17 @@
 
 class MoveRssYamlToDb < ActiveRecord::Migration[7.0]
   def up
-    rss_polling_feed_setting = DB.query("SELECT * FROM site_settings WHERE name = 'rss_polling_feed_setting' LIMIT 1").first&.value || ""
+    rss_polling_feed_setting =
+      DB
+        .query("SELECT * FROM site_settings WHERE name = 'rss_polling_feed_setting' LIMIT 1")
+        .first
+        &.value || ""
     begin
       feeds = YAML.safe_load(rss_polling_feed_setting)
       feeds&.each do |(url, author, category_id, tags, category_filter)|
         tags = tags&.join(",")
 
-        DiscourseRssPolling::RssFeed.create(
-          url:,
-          author:,
-          category_id:,
-          tags:,
-          category_filter:,
-        )
+        DiscourseRssPolling::RssFeed.create(url:, author:, category_id:, tags:, category_filter:)
       rescue Psych::SyntaxError => ex
         # We don't want the migration to fail if invalid yaml exists for some reason
       end

--- a/db/migrate/20230319115620_move_rss_yaml_to_db.rb
+++ b/db/migrate/20230319115620_move_rss_yaml_to_db.rb
@@ -18,4 +18,9 @@ class MoveRssYamlToDb < ActiveRecord::Migration[7.0]
       end
     end
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
 end

--- a/spec/jobs/poll_all_feeds_spec.rb
+++ b/spec/jobs/poll_all_feeds_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Jobs::DiscourseRssPolling::PollAllFeeds do
 
   describe "#execute" do
     before do
-      DiscourseRssPolling::RssFeed.create(url: "https://www.example.com/feed", author: "system")
-      DiscourseRssPolling::RssFeed.create(
+      DiscourseRssPolling::RssFeed.create!(url: "https://www.example.com/feed", author: "system")
+      DiscourseRssPolling::RssFeed.create!(
         url: "https://blog.discourse.org/feed/",
         author: "discourse",
       )

--- a/spec/jobs/poll_all_feeds_spec.rb
+++ b/spec/jobs/poll_all_feeds_spec.rb
@@ -8,13 +8,10 @@ RSpec.describe Jobs::DiscourseRssPolling::PollAllFeeds do
 
   describe "#execute" do
     before do
-      DiscourseRssPolling::RssFeed.create(
-        url: "https://www.example.com/feed",
-        author: "system"
-      )
+      DiscourseRssPolling::RssFeed.create(url: "https://www.example.com/feed", author: "system")
       DiscourseRssPolling::RssFeed.create(
         url: "https://blog.discourse.org/feed/",
-        author: "discourse"
+        author: "discourse",
       )
 
       SiteSetting.queue_jobs = true

--- a/spec/jobs/poll_all_feeds_spec.rb
+++ b/spec/jobs/poll_all_feeds_spec.rb
@@ -8,10 +8,14 @@ RSpec.describe Jobs::DiscourseRssPolling::PollAllFeeds do
 
   describe "#execute" do
     before do
-      SiteSetting.rss_polling_feed_setting = [
-        %w[https://www.example.com/feed system],
-        %w[https://blog.discourse.org/feed/ discourse],
-      ].to_yaml
+      DiscourseRssPolling::RssFeed.create(
+        url: "https://www.example.com/feed",
+        author: "system"
+      )
+      DiscourseRssPolling::RssFeed.create(
+        url: "https://blog.discourse.org/feed/",
+        author: "discourse"
+      )
 
       SiteSetting.queue_jobs = true
       Discourse.redis.del("rss-polling-feeds-polled")

--- a/spec/requests/feed_settings_controller_spec.rb
+++ b/spec/requests/feed_settings_controller_spec.rb
@@ -77,11 +77,7 @@ describe DiscourseRssPolling::FeedSettingsController do
 
       expect(response.status).to eq(200)
       feeds = DiscourseRssPolling::FeedSettingFinder.all
-      expected_json =
-        ActiveModel::ArraySerializer.new(
-          feeds,
-          root: :feed_settings,
-        ).to_json
+      expected_json = ActiveModel::ArraySerializer.new(feeds, root: :feed_settings).to_json
       expect(response.body).to eq(expected_json)
       expect(feeds.count).to eq(2)
     end

--- a/spec/requests/feed_settings_controller_spec.rb
+++ b/spec/requests/feed_settings_controller_spec.rb
@@ -13,7 +13,7 @@ describe DiscourseRssPolling::FeedSettingsController do
     DiscourseRssPolling::RssFeed.create(
       url: "https://blog.discourse.org/feed",
       author: "system",
-      category_id: nil,
+      category_id: 4,
       tags: nil,
       category_filter: "updates",
     )
@@ -54,6 +54,36 @@ describe DiscourseRssPolling::FeedSettingsController do
           root: :feed_settings,
         ).to_json
       expect(response.body).to eq(expected_json)
+    end
+
+    it "allows duplicate rss feed urls" do
+      put "/admin/plugins/rss_polling/feed_settings.json",
+          params: {
+            feed_settings: [
+              {
+                feed_url: "https://blog.discourse.org/feed",
+                author_username: "system",
+                discourse_category_id: 2,
+                feed_category_filter: "updates",
+              },
+              {
+                feed_url: "https://blog.discourse.org/feed",
+                author_username: "system",
+                discourse_category_id: 4,
+                feed_category_filter: "updates",
+              },
+            ],
+          }
+
+      expect(response.status).to eq(200)
+      feeds = DiscourseRssPolling::FeedSettingFinder.all
+      expected_json =
+        ActiveModel::ArraySerializer.new(
+          feeds,
+          root: :feed_settings,
+        ).to_json
+      expect(response.body).to eq(expected_json)
+      expect(feeds.count).to eq(2)
     end
   end
 end

--- a/spec/requests/feed_settings_controller_spec.rb
+++ b/spec/requests/feed_settings_controller_spec.rb
@@ -10,7 +10,7 @@ describe DiscourseRssPolling::FeedSettingsController do
 
     SiteSetting.rss_polling_enabled = true
 
-    DiscourseRssPolling::RssFeed.create(
+    DiscourseRssPolling::RssFeed.create!(
       url: "https://blog.discourse.org/feed",
       author: "system",
       category_id: 4,

--- a/spec/services/feed_setting_finder_spec.rb
+++ b/spec/services/feed_setting_finder_spec.rb
@@ -4,11 +4,18 @@ require "rails_helper"
 
 RSpec.describe DiscourseRssPolling::FeedSettingFinder do
   before do
-    SiteSetting.rss_polling_feed_setting = [
-      %w[https://www.withwww.com/feed system],
-      %w[https://withoutwww.com/feed system],
-      %w[https://blog.discourse.org/feed/ discourse],
-    ].to_yaml
+    DiscourseRssPolling::RssFeed.create(
+      url: "https://blog.discourse.org/feed/",
+      author: "system"
+    )
+    DiscourseRssPolling::RssFeed.create(
+      url: "https://www.withwww.com/feed",
+      author: "system"
+    )
+    DiscourseRssPolling::RssFeed.create(
+      url: "https://withoutwww.com/feed",
+      author: "system"
+    )
   end
 
   describe ".by_embed_url" do

--- a/spec/services/feed_setting_finder_spec.rb
+++ b/spec/services/feed_setting_finder_spec.rb
@@ -4,18 +4,9 @@ require "rails_helper"
 
 RSpec.describe DiscourseRssPolling::FeedSettingFinder do
   before do
-    DiscourseRssPolling::RssFeed.create(
-      url: "https://blog.discourse.org/feed/",
-      author: "system"
-    )
-    DiscourseRssPolling::RssFeed.create(
-      url: "https://www.withwww.com/feed",
-      author: "system"
-    )
-    DiscourseRssPolling::RssFeed.create(
-      url: "https://withoutwww.com/feed",
-      author: "system"
-    )
+    DiscourseRssPolling::RssFeed.create(url: "https://blog.discourse.org/feed/", author: "system")
+    DiscourseRssPolling::RssFeed.create(url: "https://www.withwww.com/feed", author: "system")
+    DiscourseRssPolling::RssFeed.create(url: "https://withoutwww.com/feed", author: "system")
   end
 
   describe ".by_embed_url" do

--- a/spec/services/feed_setting_finder_spec.rb
+++ b/spec/services/feed_setting_finder_spec.rb
@@ -4,9 +4,9 @@ require "rails_helper"
 
 RSpec.describe DiscourseRssPolling::FeedSettingFinder do
   before do
-    DiscourseRssPolling::RssFeed.create(url: "https://blog.discourse.org/feed/", author: "system")
-    DiscourseRssPolling::RssFeed.create(url: "https://www.withwww.com/feed", author: "system")
-    DiscourseRssPolling::RssFeed.create(url: "https://withoutwww.com/feed", author: "system")
+    DiscourseRssPolling::RssFeed.create!(url: "https://blog.discourse.org/feed/", author: "system")
+    DiscourseRssPolling::RssFeed.create!(url: "https://www.withwww.com/feed", author: "system")
+    DiscourseRssPolling::RssFeed.create!(url: "https://withoutwww.com/feed", author: "system")
   end
 
   describe ".by_embed_url" do


### PR DESCRIPTION
Every single rss feed was stored inside of a SiteSetting as a really long yaml string. This PR creates a database table to store individual rss feed records, and adds a migration to migration existing rss feeds to use that db table.