### PR TITLE
DEV: Replace deprecated queue_jobs site setting in tests

### DIFF
--- a/spec/jobs/fix_topic_embed_authors_spec.rb
+++ b/spec/jobs/fix_topic_embed_authors_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Jobs::DiscourseRssPolling::FixTopicEmbedAuthors do
   let(:job) { Jobs::DiscourseRssPolling::FixTopicEmbedAuthors.new }
 
   describe "#execute" do
-    before { SiteSetting.queue_jobs = true }
+    before { Jobs.run_later! }
 
     it "makes sure the topic and first post have the same author" do
       Sidekiq::Testing.fake! do

--- a/spec/jobs/poll_all_feeds_spec.rb
+++ b/spec/jobs/poll_all_feeds_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Jobs::DiscourseRssPolling::PollAllFeeds do
         author: "discourse",
       )
 
-      SiteSetting.queue_jobs = true
+      Jobs.run_later!
       Discourse.redis.del("rss-polling-feeds-polled")
     end
 

--- a/spec/models/feed_setting_spec.rb
+++ b/spec/models/feed_setting_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe DiscourseRssPolling::FeedSetting do
 
   describe "#poll" do
     context "with inline: false" do
-      before { SiteSetting.queue_jobs = true }
+      before { Jobs.run_later! }
 
       it "enqueues a Jobs::DiscourseRssPolling::PollFeed job with the correct arguments" do
         Sidekiq::Testing.fake! do


### PR DESCRIPTION
### What is this change?

The `#queue_jobs=` method on site settings has been [deprecated](https://github.com/discourse/discourse/commit/1b65469b64e9e569fed67ae11f1dd9ee37702f5c) and replaced by `Jobs.run_later!` and `Jobs.run_immediately!`. This PR replaces usages in this plugin so we can remove the fallback in core.

The fallback used in core for reference:

https://github.com/discourse/discourse/blob/main/app/models/site_setting.rb#L109-L115