### PR TITLE
Use pubDate as topic timestamp

### DIFF
--- a/app/jobs/jobs/discourse_rss_polling/poll_feed.rb
+++ b/app/jobs/jobs/discourse_rss_polling/poll_feed.rb
@@ -57,15 +57,16 @@ module Jobs
             updated_tags = nil if topic_exists
           end
 
-          post = TopicEmbed.import(
-            author,
-            topic.url,
-            topic.title,
-            CGI.unescapeHTML(topic.content),
-            category_id: discourse_category_id,
-            tags: updated_tags,
-            cook_method: cook_method,
-          )
+          post =
+            TopicEmbed.import(
+              author,
+              topic.url,
+              topic.title,
+              CGI.unescapeHTML(topic.content),
+              category_id: discourse_category_id,
+              tags: updated_tags,
+              cook_method: cook_method,
+            )
           if SiteSetting.rss_polling_use_pubdate && post && (post.created_at == post.updated_at) # new post
             begin
               post_time = topic.pubdate
@@ -75,7 +76,7 @@ module Jobs
               post.topic.bumped_at = post_time
               post.topic.last_posted_at = post_time
               post.topic.save!
-            rescue
+            rescue StandardError
               Rails.logger.error("Invalid pubDate for topic #{post.topic.id} #{post_time.to_s}")
             end
           end

--- a/app/jobs/jobs/discourse_rss_polling/poll_feed.rb
+++ b/app/jobs/jobs/discourse_rss_polling/poll_feed.rb
@@ -79,7 +79,7 @@ module Jobs
               post.topic.last_posted_at = post_time
               post.topic.save!
             rescue StandardError
-              Rails.logger.error("Invalid pubDate for topic #{post.topic.id} #{post_time.to_s}")
+              Rails.logger.error("Invalid pubDate for topic #{post.topic.id} #{post_time}")
             end
           end
         end

--- a/app/jobs/jobs/discourse_rss_polling/poll_feed.rb
+++ b/app/jobs/jobs/discourse_rss_polling/poll_feed.rb
@@ -58,7 +58,7 @@ module Jobs
             tags: discourse_tags,
             cook_method: cook_method,
           )
-          if SiteSetting.rss_polling_use_pubdate && (post.created_at == post.updated_at) # new post
+          if SiteSetting.rss_polling_use_pubdate && post && (post.created_at == post.updated_at) # new post
             begin
               post_time = topic.pubdate
               post.created_at = post_time

--- a/app/models/discourse_rss_polling/feed_item.rb
+++ b/app/models/discourse_rss_polling/feed_item.rb
@@ -39,6 +39,10 @@ module DiscourseRssPolling
       url&.starts_with?("https://www.youtube.com/watch")
     end
 
+    def pubdate
+      @accessor.element_content(:pubDate)
+    end
+
     private
 
     # The tag name's relative order implies its priority.

--- a/app/models/discourse_rss_polling/feed_item.rb
+++ b/app/models/discourse_rss_polling/feed_item.rb
@@ -40,7 +40,7 @@ module DiscourseRssPolling
     end
 
     def pubdate
-      @accessor.element_content(:pubDate)
+      @accessor.element_content(:pubDate) || @accessor.element_content(:published)
     end
 
     private

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2,3 +2,4 @@ en:
   site_settings:
     rss_polling_enabled: "[RSS Polling] Enable importing embed posts from multiple RSS feeds"
     rss_polling_frequency: "[RSS Polling] Feed polling frequency, in minutes"
+    rss_polling_use_pubdate: "[RSS Polling] Set topic creation date to the pubDate found in the RSS feed"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -15,3 +15,7 @@ plugins:
     max: 180
     default: 30
     client: false
+
+  rss_polling_use_pubdate:
+    default: false
+    client: false

--- a/spec/jobs/poll_feed_spec.rb
+++ b/spec/jobs/poll_feed_spec.rb
@@ -52,7 +52,9 @@ RSpec.describe Jobs::DiscourseRssPolling::PollFeed do
       it "has a publication date of the feed" do
         topic = author.topics.last
         expect(topic.created_at).to eq_time(DateTime.parse("2017-09-14 15:22:33.000000000 +0000"))
-        expect(topic.first_post.created_at).to eq_time(DateTime.parse("2017-09-14 15:22:33.000000000 +0000"))
+        expect(topic.first_post.created_at).to eq_time(
+          DateTime.parse("2017-09-14 15:22:33.000000000 +0000"),
+        )
       end
     end
 

--- a/spec/jobs/poll_feed_spec.rb
+++ b/spec/jobs/poll_feed_spec.rb
@@ -30,6 +30,32 @@ RSpec.describe Jobs::DiscourseRssPolling::PollFeed do
       )
     end
 
+    context "with use_pubdate set to false" do
+      before do
+        SiteSetting.rss_polling_use_pubdate = false
+        job.execute(feed_url: feed_url, author_username: author.username)
+      end
+
+      it "has a publication date of now" do
+        topic = author.topics.last
+        expect(topic.created_at.utc).to be_within(1.second).of Time.now
+        expect(topic.first_post.created_at.utc).to be_within(1.second).of Time.now
+      end
+    end
+
+    context "with use_pubdate set to true" do
+      before do
+        SiteSetting.rss_polling_use_pubdate = true
+        job.execute(feed_url: feed_url, author_username: author.username)
+      end
+
+      it "has a publication date of the feed" do
+        topic = author.topics.last
+        expect(topic.created_at).to eq_time(DateTime.parse("2017-09-14 15:22:33.000000000 +0000"))
+        expect(topic.first_post.created_at).to eq_time(DateTime.parse("2017-09-14 15:22:33.000000000 +0000"))
+      end
+    end
+
     context "with a previous poll on a topic with tags" do
       let(:tag1) { Fabricate(:tag, name: "test-from-rss") }
       let(:tag2) { Fabricate(:tag, name: "test-update-from-rss") }


### PR DESCRIPTION
I was going to add tests but I found that none of the fixtures were actually using RSS 2.0, all of them are Atom, using `published` instead of `pubDate`

Now the functionality uses `published` as a fallback but of course it would be better to have some RSS 2.0 test files as well. 
However that would be quite a lot of work for such a small change. So LMK what you think.