### PR TITLE
FEATURE: add an option to disable updating tags from polling

### DIFF
--- a/app/jobs/jobs/discourse_rss_polling/poll_feed.rb
+++ b/app/jobs/jobs/discourse_rss_polling/poll_feed.rb
@@ -49,13 +49,21 @@ module Jobs
 
           cook_method = topic.is_youtube? ? Post.cook_methods[:regular] : nil
 
+          updated_tags = discourse_tags
+          if !SiteSetting.rss_polling_update_tags
+            url = TopicEmbed.normalize_url(topic.url)
+            embed = TopicEmbed.topic_embed_by_url(url)
+            topic_exists = embed.present?
+            updated_tags = nil if topic_exists
+          end
+
           TopicEmbed.import(
             author,
             topic.url,
             topic.title,
             CGI.unescapeHTML(topic.content),
             category_id: discourse_category_id,
-            tags: discourse_tags,
+            tags: updated_tags,
             cook_method: cook_method,
           )
         end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -2,3 +2,4 @@ en:
   site_settings:
     rss_polling_enabled: "[RSS Polling] Enable importing embed posts from multiple RSS feeds"
     rss_polling_frequency: "[RSS Polling] Feed polling frequency, in minutes"
+    rss_polling_update_tags: "[RSS Polling] Update topic tags when a topic is updated. Disabling this pulls initial tags but disables further tag changes."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -15,3 +15,7 @@ plugins:
     max: 180
     default: 30
     client: false
+
+  rss_polling_update_tags:
+    default: true
+    client: false

--- a/spec/jobs/poll_feed_spec.rb
+++ b/spec/jobs/poll_feed_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe Jobs::DiscourseRssPolling::PollFeed do
   SiteSetting.rss_polling_enabled = true
   let(:feed_url) { "https://blog.discourse.org/feed/" }
-  let(:author) { Fabricate(:user) }
+  let(:author) { Fabricate(:user, trust_level: 1) }
   let(:raw_feed) { file_from_fixtures("feed.rss", "feed") }
   let(:job) { Jobs::DiscourseRssPolling::PollFeed.new }
 
@@ -28,6 +28,49 @@ RSpec.describe Jobs::DiscourseRssPolling::PollFeed do
       expect(topic.topic_embed.embed_url).to eq(
         "https://blog.discourse.org/2017/09/poll-feed-spec-fixture",
       )
+    end
+
+    context "with a previous poll on a topic with tags" do
+      let(:tag1) { Fabricate(:tag, name: "test-from-rss") }
+      let(:tag2) { Fabricate(:tag, name: "test-update-from-rss") }
+
+      before do
+        SiteSetting.tagging_enabled = true
+        job.execute(
+          feed_url: feed_url,
+          author_username: author.username,
+          discourse_tags: [tag1.name],
+        )
+        Discourse.redis.del("rss-polling-feed-polled:#{Digest::SHA1.hexdigest(feed_url)}")
+      end
+
+      context "with rss polling set to true" do
+        before { SiteSetting.rss_polling_update_tags = true }
+        it "updates tags by default" do
+          topic = author.topics.last
+          job.execute(
+            feed_url: feed_url,
+            author_username: author.username,
+            discourse_tags: [tag2.name],
+          )
+          topic = author.topics.last.reload
+          expect(topic.tags).to match_array([tag2])
+        end
+      end
+
+      context "with rss polling set to false" do
+        before { SiteSetting.rss_polling_update_tags = false }
+
+        it "does not update tags" do
+          job.execute(
+            feed_url: feed_url,
+            author_username: author.username,
+            discourse_tags: [tag2.name],
+          )
+          topic = author.topics.last
+          expect(topic.tags).to match_array([tag1])
+        end
+      end
     end
 
     it "is rate limited by rss_polling_frequency" do


### PR DESCRIPTION
For users who add or edit tags after RSS polling is done, this adds an option to skip tag updates

https://meta.discourse.org/t/rss-polling-plugin-removes-tags-added-manually/311811/21