### PR TITLE
FIX: prevents error with embedding with no title

### DIFF
--- a/spec/fixtures/files/mastodon.rss
+++ b/spec/fixtures/files/mastodon.rss
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:webfeeds="http://webfeeds.org/rss/1.0" xmlns:media="http://search.yahoo.com/mrss/">
+  <channel>
+    <title>Foo Bar</title>
+    <description>Public posts from @foo@mathstodon.bar</description>
+    <link>https://mathstodon.bar/@foo</link>
+    <image>
+      <url>https://mathstodon.bar/avatars/original/missing.png</url>
+      <title>Foo Bar</title>
+      <link>https://mathstodon.bar/@foo</link>
+    </image>
+    <lastBuildDate>Wed, 29 Mar 2023 20:01:49 +0000</lastBuildDate>
+    <webfeeds:icon>https://mathstodon.bar/avatars/original/missing.png</webfeeds:icon>
+    <generator>Mastodon v4.2.10</generator>
+    <item>
+      <guid isPermaLink="true">https://mathstodon.bar/@foo/123456789</guid>
+      <link>https://mathstodon.bar/@foo/123456789</link>
+      <pubDate>Wed, 29 Mar 2023 19:02:42 +0000</pubDate>
+      <description>Test</description>
+    </item>
+  </channel>
+</rss>

--- a/spec/jobs/poll_feed_spec.rb
+++ b/spec/jobs/poll_feed_spec.rb
@@ -105,5 +105,16 @@ RSpec.describe Jobs::DiscourseRssPolling::PollFeed do
         job.execute(feed_url: feed_url, author_username: author.username)
       }.not_to raise_error
     end
+
+    it "does not raise error for valid xml but non-rss title" do
+      stub_request(:get, feed_url).to_return(
+        status: 200,
+        body: rss_polling_file_fixture("mastodon.rss").read,
+      )
+
+      expect {
+        job.execute(feed_url: feed_url, author_username: author.username)
+      }.not_to raise_error
+    end
   end
 end


### PR DESCRIPTION
This fix is fixing the following error:

```
rack-mini-profiler-3.3.1/lib/patches/db/pg.rb:69:in `exec_params'
rack-mini-profiler-3.3.1/lib/patches/db/pg.rb:69:in `exec_params'
(eval at /var/www/discourse/lib/method_profiler.rb:38):105:in `exec_params'
activerecord-7.1.3.4/lib/active_record/connection_adapters/postgresql_adapter.rb:894:in `block (2 levels) in exec_no_cache'
activerecord-7.1.3.4/lib/active_record/connection_adapters/abstract_adapter.rb:1028:in `block in with_raw_connection'
activesupport-7.1.3.4/lib/active_support/concurrency/null_lock.rb:9:in `synchronize'
activerecord-7.1.3.4/lib/active_record/connection_adapters/abstract_adapter.rb:1000:in `with_raw_connection'
activerecord-7.1.3.4/lib/active_record/connection_adapters/postgresql_adapter.rb:893:in `block in exec_no_cache'
activesupport-7.1.3.4/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
activerecord-7.1.3.4/lib/active_record/connection_adapters/abstract_adapter.rb:1143:in `log'
activerecord-7.1.3.4/lib/active_record/connection_adapters/postgresql_adapter.rb:892:in `exec_no_cache'
activerecord-7.1.3.4/lib/active_record/connection_adapters/postgresql_adapter.rb:872:in `execute_and_clear'
activerecord-7.1.3.4/lib/active_record/connection_adapters/postgresql/database_statements.rb:64:in `internal_exec_query'
activerecord-7.1.3.4/lib/active_record/connection_adapters/abstract/database_statements.rb:153:in `exec_insert'
activerecord-7.1.3.4/lib/active_record/connection_adapters/postgresql/database_statements.rb:83:in `exec_insert'
activerecord-7.1.3.4/lib/active_record/connection_adapters/abstract/database_statements.rb:191:in `insert'
activerecord-7.1.3.4/lib/active_record/connection_adapters/abstract/query_cache.rb:25:in `insert'
activerecord-7.1.3.4/lib/active_record/persistence.rb:588:in `_insert_record'
activerecord-7.1.3.4/lib/active_record/persistence.rb:1252:in `_create_record'
activerecord-7.1.3.4/lib/active_record/counter_cache.rb:187:in `_create_record'
activerecord-7.1.3.4/lib/active_record/locking/optimistic.rb:84:in `_create_record'
activerecord-7.1.3.4/lib/active_record/encryption/encryptable_record.rb:184:in `_create_record'
activerecord-7.1.3.4/lib/active_record/attribute_methods/dirty.rb:240:in `_create_record'
activerecord-7.1.3.4/lib/active_record/callbacks.rb:445:in `block in _create_record'
activesupport-7.1.3.4/lib/active_support/callbacks.rb:110:in `run_callbacks'
activesupport-7.1.3.4/lib/active_support/callbacks.rb:952:in `_run_create_callbacks'
activerecord-7.1.3.4/lib/active_record/callbacks.rb:445:in `_create_record'
activerecord-7.1.3.4/lib/active_record/timestamp.rb:114:in `_create_record'
activerecord-7.1.3.4/lib/active_record/persistence.rb:1221:in `create_or_update'
activerecord-7.1.3.4/lib/active_record/callbacks.rb:441:in `block in create_or_update'
activesupport-7.1.3.4/lib/active_support/callbacks.rb:121:in `block in run_callbacks'
activerecord-7.1.3.4/lib/active_record/autosave_association.rb:375:in `around_save_collection_association'
activesupport-7.1.3.4/lib/active_support/callbacks.rb:130:in `block in run_callbacks'
activesupport-7.1.3.4/lib/active_support/callbacks.rb:141:in `run_callbacks'
activesupport-7.1.3.4/lib/active_support/callbacks.rb:952:in `_run_save_callbacks'
activerecord-7.1.3.4/lib/active_record/callbacks.rb:441:in `create_or_update'
activerecord-7.1.3.4/lib/active_record/timestamp.rb:125:in `create_or_update'
activerecord-7.1.3.4/lib/active_record/persistence.rb:718:in `save'
activerecord-7.1.3.4/lib/active_record/validations.rb:49:in `save'
activerecord-7.1.3.4/lib/active_record/transactions.rb:309:in `block in save'
activerecord-7.1.3.4/lib/active_record/transactions.rb:365:in `block in with_transaction_returning_status'
activerecord-7.1.3.4/lib/active_record/connection_adapters/abstract/database_statements.rb:342:in `transaction'
activerecord-7.1.3.4/lib/active_record/transactions.rb:361:in `with_transaction_returning_status'
activerecord-7.1.3.4/lib/active_record/transactions.rb:309:in `save'
activerecord-7.1.3.4/lib/active_record/suppressor.rb:52:in `save'
/var/www/discourse/lib/topic_creator.rb:237:in `save_topic'
/var/www/discourse/lib/topic_creator.rb:58:in `create'
/var/www/discourse/lib/post_creator.rb:490:in `create_topic'
/var/www/discourse/lib/post_creator.rb:190:in `block in create'
/var/www/discourse/lib/post_creator.rb:390:in `block in transaction'
activerecord-7.1.3.4/lib/active_record/connection_adapters/abstract/database_statements.rb:342:in `transaction'
activerecord-7.1.3.4/lib/active_record/transactions.rb:212:in `transaction'
/var/www/discourse/lib/post_creator.rb:390:in `transaction'
/var/www/discourse/lib/post_creator.rb:188:in `create'
/var/www/discourse/lib/post_creator.rb:270:in `create'
/var/www/discourse/app/models/topic_embed.rb:98:in `block in import'
activerecord-7.1.3.4/lib/active_record/connection_adapters/abstract/transaction.rb:535:in `block in within_new_transaction'
activesupport-7.1.3.4/lib/active_support/concurrency/null_lock.rb:9:in `synchronize'
activerecord-7.1.3.4/lib/active_record/connection_adapters/abstract/transaction.rb:532:in `within_new_transaction'
activerecord-7.1.3.4/lib/active_record/connection_adapters/abstract/database_statements.rb:344:in `transaction'
activerecord-7.1.3.4/lib/active_record/transactions.rb:212:in `transaction'
/var/www/discourse/app/models/topic_embed.rb:62:in `import'
/var/www/discourse/plugins/discourse-rss-polling/app/jobs/jobs/discourse_rss_polling/poll_feed.rb:60:in `block in poll_feed'
/var/www/discourse/plugins/discourse-rss-polling/app/jobs/jobs/discourse_rss_polling/poll_feed.rb:41:in `each'
/var/www/discourse/plugins/discourse-rss-polling/app/jobs/jobs/discourse_rss_polling/poll_feed.rb:41:in `poll_feed'
/var/www/discourse/plugins/discourse-rss-polling/app/jobs/jobs/discourse_rss_polling/poll_feed.rb:20:in `execute'
```

We were not able to extract a title from some feeds, and yet we would still try to create a TopicEmber from it. The bulk of the fix is to exit early if we didn't can't extract a title.

Note this commit also renames `topic` into `feed_item`, as the naming was misleading, we have a `FeedItem` object, not a `Topic` object.