### PR TITLE
DEV: Update more deprecated Font Awesome icon names

### DIFF
--- a/assets/javascripts/discourse/templates/admin/plugins-rss-polling.hbs
+++ b/assets/javascripts/discourse/templates/admin/plugins-rss-polling.hbs
@@ -6,7 +6,7 @@
         <th colspan="3">{{i18n "admin.rss_polling.discourse"}}</th>
         <th rowspan="2">
           <DButton
-            @icon="save"
+            @icon="floppy-disk"
             @action={{action "update"}}
             @disabled={{this.unsavable}}
             class="btn-primary"
@@ -66,7 +66,7 @@
           </td>
           <td>
             <DButton
-              @icon="times"
+              @icon="xmark"
               @action={{action "destroyFeedSetting" setting}}
               @disabled={{this.saving}}
             />


### PR DESCRIPTION
This PR updates more deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.