### PR TITLE
DEV: Improve admin interface UI

### DIFF
--- a/app/controllers/discourse_rss_polling/feed_settings_controller.rb
+++ b/app/controllers/discourse_rss_polling/feed_settings_controller.rb
@@ -19,7 +19,7 @@ module DiscourseRssPolling
           author: feed["author_username"],
           category_id: feed["discourse_category_id"],
           tags: feed["discourse_tags"]&.join(","),
-          category_filter: feed["feed_category_filter"]
+          category_filter: feed["feed_category_filter"],
         )
         if rss_feed.save
           render json: { success: true }

--- a/app/controllers/discourse_rss_polling/feed_settings_controller.rb
+++ b/app/controllers/discourse_rss_polling/feed_settings_controller.rb
@@ -9,49 +9,38 @@ module DiscourseRssPolling
     end
 
     def update
-      if params[:feed_settings] == []
-        RssFeed.destroy_all
-      else
-        # Temporary until we start using IDs from the db
-        # and can update individual items
-        if feed_setting_params.presence
-          current_feeds = RssFeed.all.to_a
-          feed_setting_params.each do |feed|
-            current_feeds.delete_if do |h|
-              h.url == feed["feed_url"] && h.category_id == feed["discourse_category_id"].to_i &&
-                h.category_filter == feed["feed_category_filter"]
-            end
-            rss_feed =
-              RssFeed.find_by(
-                url: feed["feed_url"],
-                category_id: feed["discourse_category_id"],
-                category_filter: feed["feed_category_filter"],
-              )
-            if rss_feed
-              rss_feed.update!(
-                url: feed["feed_url"],
-                author: feed["author_username"],
-                category_id: feed["discourse_category_id"],
-                tags: feed["discourse_tags"]&.join(","),
-                category_filter: feed["feed_category_filter"],
-              )
-            else
-              RssFeed.create!(
-                url: feed["feed_url"],
-                author: feed["author_username"],
-                category_id: feed["discourse_category_id"],
-                tags: feed["discourse_tags"]&.join(","),
-                category_filter: feed["feed_category_filter"],
-              )
-            end
+      feed = params[:feed_setting]
 
-            # Delete any remaining feeds
-            current_feeds.each { |f| RssFeed.destroy_by(id: f.id) }
-          end
+      if feed
+        rss_feed = RssFeed.find_by_id(feed["id"]) || RssFeed.new
+
+        rss_feed.assign_attributes(
+          url: feed["feed_url"],
+          author: feed["author_username"],
+          category_id: feed["discourse_category_id"],
+          tags: feed["discourse_tags"]&.join(","),
+          category_filter: feed["feed_category_filter"]
+        )
+        if rss_feed.save
+          render json: { success: true }
+        else
+          render json: { success: false, errors: rss_feed.errors.full_messages }, status: 422
         end
+      else
+        render json: { success: false, error: "Invalid feed data" }, status: 400
       end
+    end
 
-      render json: FeedSettingFinder.all
+    def destroy
+      feed = params[:feed_setting]
+      rss_feed = RssFeed.find_by_id(feed["id"])
+
+      if rss_feed
+        rss_feed.destroy
+        render json: { success: true }
+      else
+        render json: { success: false, error: "Feed not found" }, status: 404
+      end
     end
 
     private

--- a/app/controllers/discourse_rss_polling/feed_settings_controller.rb
+++ b/app/controllers/discourse_rss_polling/feed_settings_controller.rb
@@ -36,7 +36,7 @@ module DiscourseRssPolling
       rss_feed = RssFeed.find_by_id(feed["id"])
 
       if rss_feed
-        rss_feed.destroy
+        rss_feed.destroy!
         render json: { success: true }
       else
         render json: { success: false, error: "Feed not found" }, status: 404

--- a/app/models/discourse_rss_polling/feed_setting.rb
+++ b/app/models/discourse_rss_polling/feed_setting.rb
@@ -5,6 +5,7 @@ module DiscourseRssPolling
     include ActiveModel::Serialization
 
     attr_accessor(
+      :id,
       :feed_url,
       :author_username,
       :discourse_category_id,
@@ -13,12 +14,14 @@ module DiscourseRssPolling
     )
 
     def initialize(
+      id: nil,
       feed_url:,
       author_username:,
       discourse_category_id:,
       discourse_tags:,
       feed_category_filter:
     )
+      @id = id
       @feed_url = feed_url
       @author_username = author_username
       @discourse_category_id = discourse_category_id

--- a/app/services/discourse_rss_polling/feed_setting_finder.rb
+++ b/app/services/discourse_rss_polling/feed_setting_finder.rb
@@ -7,6 +7,7 @@ module DiscourseRssPolling
       feed = RssFeed.where("url LIKE ?", "%#{host}%").first
       return nil if !feed
       FeedSetting.new(
+        id: feed.id,
         feed_url: feed.url,
         author_username: feed.author,
         discourse_category_id: feed.category_id,
@@ -31,6 +32,7 @@ module DiscourseRssPolling
     def all
       RssFeed.all.map do |feed|
         FeedSetting.new(
+          id: feed.id,
           feed_url: feed.url,
           author_username: feed.author,
           discourse_category_id: feed.category_id,

--- a/assets/javascripts/admin/models/rss-polling-feed-settings.js
+++ b/assets/javascripts/admin/models/rss-polling-feed-settings.js
@@ -5,12 +5,21 @@ export default {
     return ajax("/admin/plugins/rss_polling/feed_settings.json");
   },
 
-  update(feedSettings) {
+  updateFeed(feedSetting) {
     return ajax("/admin/plugins/rss_polling/feed_settings", {
       type: "PUT",
       contentType: "application/json",
       processData: false,
-      data: JSON.stringify({ feed_settings: feedSettings }),
+      data: JSON.stringify({ feed_setting: feedSetting }),
+    });
+  },
+
+  deleteFeed(feedSetting) {
+    return ajax("/admin/plugins/rss_polling/feed_settings", {
+      type: "DELETE",
+      contentType: "application/json",
+      processData: false,
+      data: JSON.stringify({ feed_setting: feedSetting }),
     });
   },
 };

--- a/assets/javascripts/discourse/controllers/admin-plugins-rss-polling.js
+++ b/assets/javascripts/discourse/controllers/admin-plugins-rss-polling.js
@@ -75,6 +75,9 @@ export default class AdminPluginsRssPollingController extends Controller {
 
   @action
   cancelEdit(setting) {
+    if (!setting.id) {
+      this.get("feedSettings").removeObject(setting);
+    }
     set(setting, "disabled", true);
     set(setting, "editing", false);
   }

--- a/assets/javascripts/discourse/controllers/admin-plugins-rss-polling.js
+++ b/assets/javascripts/discourse/controllers/admin-plugins-rss-polling.js
@@ -4,10 +4,10 @@ import { alias } from "@ember/object/computed";
 import { service } from "@ember/service";
 import { isBlank } from "@ember/utils";
 import { observes } from "@ember-decorators/object";
+import { popupAjaxError } from "discourse/lib/ajax-error";
 import discourseComputed from "discourse-common/utils/decorators";
 import { i18n } from "discourse-i18n";
 import RssPollingFeedSettings from "../../admin/models/rss-polling-feed-settings";
-import { popupAjaxError } from "discourse/lib/ajax-error";
 
 export default class AdminPluginsRssPollingController extends Controller {
   @service dialog;

--- a/assets/javascripts/discourse/controllers/admin-plugins-rss-polling.js
+++ b/assets/javascripts/discourse/controllers/admin-plugins-rss-polling.js
@@ -45,7 +45,7 @@ export default class AdminPluginsRssPollingController extends Controller {
       discourse_tags: null,
       feed_category_filter: null,
       disabled: false,
-      editing: true
+      editing: true,
     };
 
     this.get("feedSettings").addObject(newSetting);
@@ -84,8 +84,7 @@ export default class AdminPluginsRssPollingController extends Controller {
     this.set("saving", true);
 
     RssPollingFeedSettings.updateFeed(setting)
-      .then(() => {
-      })
+      .then(() => {})
       .finally(() => {
         this.set("saving", false);
         set(setting, "disabled", true);

--- a/assets/javascripts/discourse/routes/admin-plugins-rss-polling.js
+++ b/assets/javascripts/discourse/routes/admin-plugins-rss-polling.js
@@ -7,6 +7,11 @@ export default class AdminPluginsRssPolling extends DiscourseRoute {
   }
 
   setupController(controller, model) {
+    model.forEach((setting) => {
+      setting.disabled = true;
+      setting.editing = false;
+    });
+
     controller.setProperties({
       model,
     });

--- a/assets/javascripts/discourse/templates/admin/plugins-rss-polling.hbs
+++ b/assets/javascripts/discourse/templates/admin/plugins-rss-polling.hbs
@@ -5,11 +5,17 @@
         <th colspan="2">{{i18n "admin.rss_polling.feed"}}</th>
         <th colspan="3">{{i18n "admin.rss_polling.discourse"}}</th>
         <th rowspan="2">
-          <DButton
+          {{!-- <DButton
             @icon="floppy-disk"
             @action={{action "update"}}
             @disabled={{this.unsavable}}
             class="btn-primary"
+          /> --}}
+          <DButton
+            @action={{action "create"}}
+            @icon="plus"
+            @disabled={{this.saving}}
+            class="btn-secondary"
           />
         </th>
       </tr>
@@ -29,28 +35,33 @@
             <Input
               @value={{setting.feed_url}}
               placeholder="https://blog.example.com/feed"
-              disabled={{this.saving}}
+              disabled={{setting.disabled}}
             />
           </td>
           <td>
             <Input
               @value={{setting.feed_category_filter}}
               placeholder="updates"
-              disabled={{this.saving}}
+              disabled={{setting.disabled}}
             />
           </td>
           <td>
             <EmailGroupUserChooser
               @value={{setting.author_username}}
-              @disabled={{this.saving}}
               @onChange={{action "updateAuthorUsername" setting}}
-              @options={{hash maximum=1}}
+              @options={{hash
+                disabled=setting.disabled
+                maximum=1
+              }}
             />
           </td>
           <td>
             <CategoryChooser
               @value={{setting.discourse_category_id}}
               @onChange={{action (mut setting.discourse_category_id)}}
+              @options={{hash
+                disabled=setting.disabled
+              }}
               class="small"
             />
           </td>
@@ -61,15 +72,37 @@
               @everyTag={{true}}
               @unlimitedTagCount={{true}}
               @onChange={{action (mut setting.discourse_tags)}}
+              @options={{hash
+                disabled=setting.disabled
+              }}
               class="small"
             />
           </td>
           <td>
-            <DButton
-              @icon="xmark"
-              @action={{action "destroyFeedSetting" setting}}
-              @disabled={{this.saving}}
-            />
+            {{#if setting.editing}}
+              <DButton
+                @icon="floppy-disk"
+                @action={{action "updateFeedSetting" setting}}
+                @disabled={{this.unsavable}}
+                class="btn-primary"
+              />
+              <DButton
+                @icon="xmark"
+                @action={{action "cancelEdit" setting}}
+                @disabled={{this.saving}}
+              />
+            {{else}}
+              <DButton
+                @icon="pencil"
+                @action={{action "editFeedSetting" setting}}
+                @disabled={{this.saving}}
+              />
+              <DButton
+                @icon="trash-can"
+                @action={{action "destroyFeedSetting" setting}}
+                @disabled={{this.saving}}
+              />
+            {{/if}}
           </td>
         </tr>
       {{/each}}
@@ -82,14 +115,7 @@
         <td></td>
         <td></td>
         <td></td>
-        <td>
-          <DButton
-            @action={{action "create"}}
-            @icon="plus"
-            @disabled={{this.saving}}
-            class="btn-secondary"
-          />
-        </td>
+        <td></td>
       </tr>
     </tfoot>
   </table>

--- a/assets/javascripts/discourse/templates/admin/plugins-rss-polling.hbs
+++ b/assets/javascripts/discourse/templates/admin/plugins-rss-polling.hbs
@@ -4,18 +4,12 @@
       <tr>
         <th colspan="2">{{i18n "admin.rss_polling.feed"}}</th>
         <th colspan="3">{{i18n "admin.rss_polling.discourse"}}</th>
-        <th rowspan="2">
-          {{!-- <DButton
-            @icon="floppy-disk"
-            @action={{action "update"}}
-            @disabled={{this.unsavable}}
-            class="btn-primary"
-          /> --}}
+        <th rowspan="2" colspan="2">
           <DButton
             @action={{action "create"}}
             @icon="plus"
             @disabled={{this.saving}}
-            class="btn-secondary"
+            class="btn-primary wide-button"
           />
         </th>
       </tr>

--- a/assets/javascripts/discourse/templates/admin/plugins-rss-polling.hbs
+++ b/assets/javascripts/discourse/templates/admin/plugins-rss-polling.hbs
@@ -69,7 +69,7 @@
             {{#if setting.editing}}
               <DButton
                 @icon="floppy-disk"
-                @action={{action "updateFeedSetting" setting}}
+                @action={{fn this.updateFeedSetting setting}}
                 @disabled={{this.unsavable}}
                 class="btn-primary"
               />

--- a/assets/javascripts/discourse/templates/admin/plugins-rss-polling.hbs
+++ b/assets/javascripts/discourse/templates/admin/plugins-rss-polling.hbs
@@ -49,19 +49,14 @@
             <EmailGroupUserChooser
               @value={{setting.author_username}}
               @onChange={{action "updateAuthorUsername" setting}}
-              @options={{hash
-                disabled=setting.disabled
-                maximum=1
-              }}
+              @options={{hash disabled=setting.disabled maximum=1}}
             />
           </td>
           <td>
             <CategoryChooser
               @value={{setting.discourse_category_id}}
               @onChange={{action (mut setting.discourse_category_id)}}
-              @options={{hash
-                disabled=setting.disabled
-              }}
+              @options={{hash disabled=setting.disabled}}
               class="small"
             />
           </td>
@@ -72,9 +67,7 @@
               @everyTag={{true}}
               @unlimitedTagCount={{true}}
               @onChange={{action (mut setting.discourse_tags)}}
-              @options={{hash
-                disabled=setting.disabled
-              }}
+              @options={{hash disabled=setting.disabled}}
               class="small"
             />
           </td>

--- a/assets/stylesheets/rss-polling.scss
+++ b/assets/stylesheets/rss-polling.scss
@@ -22,5 +22,10 @@
         }
       }
     }
+
+    .wide-button {
+      width: 100%;
+      text-align: center;
+    }
   }
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,5 @@
 DiscourseRssPolling::Engine.routes.draw do
   root "feed_settings#show"
 
-  resource :feed_settings, constraints: StaffConstraint.new, only: %i[show update]
+  resource :feed_settings, constraints: StaffConstraint.new, only: %i[show update destroy]
 end

--- a/spec/requests/feed_settings_controller_spec.rb
+++ b/spec/requests/feed_settings_controller_spec.rb
@@ -9,17 +9,19 @@ describe DiscourseRssPolling::FeedSettingsController do
     sign_in(admin)
 
     SiteSetting.rss_polling_enabled = true
-
-    DiscourseRssPolling::RssFeed.create!(
-      url: "https://blog.discourse.org/feed",
-      author: "system",
-      category_id: 4,
-      tags: nil,
-      category_filter: "updates",
-    )
   end
 
   describe "#show" do
+    before do
+      DiscourseRssPolling::RssFeed.create!(
+        url: "https://blog.discourse.org/feed",
+        author: "system",
+        category_id: 4,
+        tags: nil,
+        category_filter: "updates",
+      )
+    end
+
     it "returns the serialized feed settings" do
       expected_json =
         ActiveModel::ArraySerializer.new(
@@ -38,47 +40,43 @@ describe DiscourseRssPolling::FeedSettingsController do
     it "updates rss feeds" do
       put "/admin/plugins/rss_polling/feed_settings.json",
           params: {
-            feed_settings: [
-              {
-                feed_url: "https://www.newsite.com/feed",
-                author_username: "system",
-                feed_category_filter: "updates",
-              },
-            ],
+            feed_setting: {
+              feed_url: "https://www.newsite.com/feed",
+              author_username: "system",
+              feed_category_filter: "updates",
+            },
           }
 
       expect(response.status).to eq(200)
-      expected_json =
-        ActiveModel::ArraySerializer.new(
-          DiscourseRssPolling::FeedSettingFinder.all,
-          root: :feed_settings,
-        ).to_json
-      expect(response.body).to eq(expected_json)
+      feeds = DiscourseRssPolling::FeedSettingFinder.all
+      expect(feeds.count).to eq(1)
     end
 
     it "allows duplicate rss feed urls" do
       put "/admin/plugins/rss_polling/feed_settings.json",
           params: {
-            feed_settings: [
-              {
-                feed_url: "https://blog.discourse.org/feed",
-                author_username: "system",
-                discourse_category_id: 2,
-                feed_category_filter: "updates",
-              },
-              {
-                feed_url: "https://blog.discourse.org/feed",
-                author_username: "system",
-                discourse_category_id: 4,
-                feed_category_filter: "updates",
-              },
-            ],
+            feed_setting: {
+              feed_url: "https://blog.discourse.org/feed",
+              author_username: "system",
+              discourse_category_id: 2,
+              feed_category_filter: "updates",
+            },
+          }
+
+      expect(response.status).to eq(200)
+
+      put "/admin/plugins/rss_polling/feed_settings.json",
+          params: {
+            feed_setting: {
+              feed_url: "https://blog.discourse.org/feed",
+              author_username: "system",
+              discourse_category_id: 4,
+              feed_category_filter: "updates",
+            },
           }
 
       expect(response.status).to eq(200)
       feeds = DiscourseRssPolling::FeedSettingFinder.all
-      expected_json = ActiveModel::ArraySerializer.new(feeds, root: :feed_settings).to_json
-      expect(response.body).to eq(expected_json)
       expect(feeds.count).to eq(2)
     end
   end


### PR DESCRIPTION
The rss feeds used to be stored in a single site setting. They are now
stored in the a proper db table, but the admin interface was never
updated to reflect this. This commit updates the admin interface UI so
that there are individual create, edit, and destroy buttons for each
feed.

This should also address: https://meta.discourse.org/t/343372

Follow up to: 73ac61823cb663295fa673d4488acbc6822c4711
