### PR TITLE
FIX: ensures user can be set on rss polling feed

### DIFF
--- a/assets/javascripts/discourse/templates/admin/plugins-rss-polling.gjs
+++ b/assets/javascripts/discourse/templates/admin/plugins-rss-polling.gjs
@@ -20,7 +20,7 @@ export default RouteTemplate(
                 @action={{@controller.create}}
                 @icon="plus"
                 @disabled={{@controller.saving}}
-                class="btn-primary wide-button"
+                class="btn-primary wide-button add-rss-polling-feed"
               />
             </th>
           </tr>
@@ -41,6 +41,7 @@ export default RouteTemplate(
                   @value={{setting.feed_url}}
                   placeholder="https://blog.example.com/feed"
                   disabled={{setting.disabled}}
+                  class="rss-polling-feed-url"
                 />
               </td>
               <td>
@@ -48,13 +49,15 @@ export default RouteTemplate(
                   @value={{setting.feed_category_filter}}
                   placeholder="updates"
                   disabled={{setting.disabled}}
+                  class="rss-polling-feed-updates"
                 />
               </td>
               <td>
                 <EmailGroupUserChooser
                   @value={{setting.author_username}}
-                  @onChange={{fn "updateAuthorUsername" setting}}
+                  @onChange={{fn @controller.updateAuthorUsername setting}}
                   @options={{hash disabled=setting.disabled maximum=1}}
+                  class="rss-polling-feed-user"
                 />
               </td>
               <td>
@@ -62,7 +65,7 @@ export default RouteTemplate(
                   @value={{setting.discourse_category_id}}
                   @onChange={{fn (mut setting.discourse_category_id)}}
                   @options={{hash disabled=setting.disabled}}
-                  class="small"
+                  class="small rss-polling-feed-category"
                 />
               </td>
               <td>
@@ -73,7 +76,7 @@ export default RouteTemplate(
                   @unlimitedTagCount={{true}}
                   @onChange={{fn (mut setting.discourse_tags)}}
                   @options={{hash disabled=setting.disabled}}
-                  class="small"
+                  class="small rss-polling-feed-tag"
                 />
               </td>
               <td>
@@ -82,7 +85,7 @@ export default RouteTemplate(
                     @icon="floppy-disk"
                     @action={{fn @controller.updateFeedSetting setting}}
                     @disabled={{@controller.unsavable}}
-                    class="btn-primary"
+                    class="btn-primary save-rss-polling-feed"
                   />
                   <DButton
                     @icon="xmark"

--- a/spec/system/admin_spec.rb
+++ b/spec/system/admin_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+RSpec.describe "Rss Polling - admin", type: :system do
+  fab!(:current_user) { Fabricate(:admin) }
+  fab!(:category_1) { Fabricate(:category) }
+  fab!(:tag_1) { Fabricate(:tag) }
+
+  let(:url) { "http://example.com/rss" }
+
+  before do
+    SiteSetting.rss_polling_enabled = true
+    sign_in(current_user)
+  end
+
+  it "can save an rss polling configuration" do
+    visit("/admin/plugins/rss_polling")
+
+    find(".add-rss-polling-feed").click
+    find(".rss-polling-feed-url").fill_in(with: url)
+    find(".rss-polling-feed-updates").fill_in(with: "updates")
+    user = PageObjects::Components::SelectKit.new(".rss-polling-feed-user")
+    user.search(current_user.username)
+    user.select_row_by_value(current_user.username)
+    category = PageObjects::Components::SelectKit.new(".rss-polling-feed-category")
+    category.search(category_1.name)
+    category.select_row_by_value(category_1.id)
+    tag = PageObjects::Components::SelectKit.new(".rss-polling-feed-tag")
+    tag.search(tag_1.name)
+    tag.select_row_by_value(tag_1.name)
+    find(".save-rss-polling-feed").click
+
+    try_until_success do
+      expect(DiscourseRssPolling::RssFeed.last).to have_attributes(
+        url:,
+        author: current_user.username,
+        category_filter: "updates",
+        category_id: category_1.id,
+        tags: tag_1.name,
+      )
+    end
+  end
+end


### PR DESCRIPTION
A recent commit: https://github.com/discourse/discourse-rss-polling/commit/7b6d68d5ad1a0431151f75c4748d90123a5406be, didn't change one of the functions resulting in an error as there was no test.

This commit fixes the issue and adds a basic spec to ensure we can create rss polling feeds.